### PR TITLE
added mix test.watch alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Enable it by adding _elixir_ to the [_plugins array_](https://github.com/robbyru
 | mrnh                     | mix run --no-halt
 | mrl                      | mix release
 | mt                       | mix test                         
+| mtw                      | mix test.watch
 | hrmec                    | heroku run mix ecto.create       
 | hrmem                    | heroku run mix ecto.migrate      
 | kd                       | kiex default

--- a/elixir.plugin.zsh
+++ b/elixir.plugin.zsh
@@ -35,6 +35,7 @@ alias mr='mix run'
 alias mrnh='mix run --no-halt'
 alias mrl='mix release'
 alias mt='mix test'
+alias mtw='mix test.watch'
 
 # Heroku
 alias hrmec='heroku run mix ecto.create'


### PR DESCRIPTION
Added alias for [mix test.watch](https://github.com/lpil/mix-test.watch), because I use it a lot during development. And it seems to be pretty popular in the community for TDD.