### PR TITLE
Add alias to mix format.

### DIFF
--- a/elixir.plugin.zsh
+++ b/elixir.plugin.zsh
@@ -49,6 +49,7 @@ alias mt='mix test'
 alias mts='mix test --stale'
 alias mtw='mix test.watch'
 alias mx='mix xref'
+alias mf='mix format'
 
 # Heroku
 alias hri='heroku run "POOL_SIZE=2 iex -S mix"'


### PR DESCRIPTION
Add an alias `mf` to run `mix format` which is available since *1.5.1-dev* and it is now available in the most recent stable version *1.6.0*